### PR TITLE
Fix exporting big textures, the process was async and did not wait for the export to finish.

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -146,6 +146,7 @@ class SubstancePainterEngine(Engine):
         self._qt_app = None
         self._dcc_app = None
         self._menu_generator = None
+        self._event_callbacks = {}
 
         Engine.__init__(self, *args, **kwargs)
 
@@ -344,6 +345,23 @@ class SubstancePainterEngine(Engine):
                 self.destroy_engine()
                 self. _qt_app.quit()
 
+        if method in self._event_callbacks:
+            self.logger.info("About to run callbacks for %s" % method)
+            for fn in self._event_callbacks[method]:
+                self.logger.info("  callback: %s" % fn)
+                fn(**kwargs)
+
+    def register_event_callback(self, event_type, callback_fn):
+        if event_type not in self._event_callbacks:
+            self._event_callbacks[event_type] = []
+        self._event_callbacks[event_type].append(callback_fn)
+
+    def unregister_event_callback(self, event_type, callback_fn):
+        if event_type not in self._event_callbacks:
+            return
+
+        if callback_fn in self._event_callbacks[event_type]:
+            self._event_callbacks[event_type].remove(callback_fn)
 
     def pre_app_init(self):
         """

--- a/resources/plugins/shotgun_bridge/main.qml
+++ b/resources/plugins/shotgun_bridge/main.qml
@@ -467,7 +467,10 @@ PainterPlugin
     var export_preset = alg.mapexport.getProjectExportPreset();
     var export_options = alg.mapexport.getProjectExportOptions();
     var export_path = data.destination;
-    return alg.mapexport.exportDocumentMaps(export_preset, export_path, export_options.fileFormat)
+    server.sendCommand("EXPORT_STARTED", {});
+    var result = alg.mapexport.exportDocumentMaps(export_preset, export_path, export_options.fileFormat)
+    server.sendCommand("EXPORT_FINISHED", {map_infos:result});
+    return true;
   }
 
   function updateDocumentResources(data)


### PR DESCRIPTION
Added event callbacks to the engine, so hooks or external functional can react to Substance Painter Events. One example is for when exporting maps, as the process was async due to the server/client nature and we needed to wait until the maps are exported for the publishing process to proceed correctly